### PR TITLE
fix: p2p encoding, metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,7 +4145,7 @@ dependencies = [
  "rw-stream-sink",
  "smallvec 1.11.1",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -4193,7 +4193,7 @@ dependencies = [
  "regex",
  "sha2 0.10.8",
  "smallvec 1.11.1",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -4293,7 +4293,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "smallvec 1.11.1",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -4736,7 +4736,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "url",
 ]
 
@@ -4758,7 +4758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -4778,7 +4778,7 @@ dependencies = [
  "log",
  "pin-project",
  "smallvec 1.11.1",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5717,7 +5717,7 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -7069,8 +7069,10 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -8233,6 +8235,16 @@ checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
  "asynchronous-codec",
  "bytes",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+dependencies = [
+ "bytes",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -28,7 +28,9 @@ ssz_rs = { workspace = true }
 ssz_rs_derive = { workspace = true }
 thiserror = "1"
 tokio = { workspace = true }
+tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = { workspace = true }
+unsigned-varint = { version = "0.8.0", features = ["codec"] }
 
 [dependencies.libp2p]
 version = "0.52.3"

--- a/crates/p2p/src/config.rs
+++ b/crates/p2p/src/config.rs
@@ -1,9 +1,16 @@
 use discv5::ListenConfig;
 use libp2p::{multiaddr::Protocol, Multiaddr};
+use ssz_rs::Bitvector;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 const DEFAULT_UDP_PORT: u16 = 9000;
 const DEFAULT_TCP_PORT: u16 = 9000;
+
+#[derive(ssz_rs_derive::Serializable, Clone, Debug, PartialEq, Default)]
+pub struct Metadata {
+    pub seq_number: u64,
+    pub mempool_nets: Bitvector<64>,
+}
 
 /// The address to listen on for incoming connections.
 /// Ip could be ipv4 or ipv6

--- a/crates/p2p/src/peer_manager/peerdb.rs
+++ b/crates/p2p/src/peer_manager/peerdb.rs
@@ -1,3 +1,4 @@
+use crate::config::Metadata;
 use libp2p::PeerId;
 use std::collections::HashMap;
 
@@ -5,8 +6,10 @@ pub enum ConnectionStatus {
     Connected,
     Disconnected,
 }
+
 pub struct PeerInfo {
     connection_status: ConnectionStatus,
+    _metadata: Option<Metadata>, // TODO: need to handle metadata updates
 }
 
 #[derive(Default)]
@@ -27,6 +30,7 @@ impl PeerDB {
             .and_modify(|info| info.connection_status = ConnectionStatus::Connected)
             .or_insert(PeerInfo {
                 connection_status: ConnectionStatus::Connected,
+                _metadata: None,
             });
     }
 

--- a/crates/p2p/src/request_response/behaviour.rs
+++ b/crates/p2p/src/request_response/behaviour.rs
@@ -89,7 +89,7 @@ pub enum InboundFailure {
     /// due to the [`ResponseChannel`] being dropped instead of
     /// being passed to [`Behaviour::send_response`].
     ResponseOmission,
-    /// Error happended while handleing the inbound
+    /// Error happended while handling the inbound
     BoundError(BoundError),
 }
 #[derive(Debug)]

--- a/crates/p2p/src/request_response/models.rs
+++ b/crates/p2p/src/request_response/models.rs
@@ -1,5 +1,6 @@
+use crate::config::Metadata;
 use silius_primitives::UserOperation;
-use ssz_rs::{Bitvector, List, Serialize, Vector};
+use ssz_rs::{List, Serialize, Vector};
 use std::io;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -7,7 +8,7 @@ pub enum Request {
     Status(Status),
     GoodbyeReason(GoodbyeReason),
     Ping(Ping),
-    GetMetaData(GetMetaData),
+    GetMetadata(GetMetadata),
     PooledUserOpHashesReq(PooledUserOpHashesReq),
     PooledUserOpsByHashReq(PooledUserOpsByHashReq),
 }
@@ -104,16 +105,10 @@ pub struct PooledUserOpsByHashReq {
     hashes: List<Vector<u8, 32>, 1024>,
 }
 
-#[derive(ssz_rs_derive::Serializable, Clone, Debug, PartialEq, Default)]
-pub struct MetaData {
-    seq_number: u64,
-    mempool_nets: Bitvector<32>,
-}
-
 #[derive(Clone, Debug, PartialEq, Default)]
-pub struct GetMetaData;
+pub struct GetMetadata;
 
-impl ssz_rs::Serializable for GetMetaData {
+impl ssz_rs::Serializable for GetMetadata {
     fn is_variable_size() -> bool {
         false
     }
@@ -122,18 +117,18 @@ impl ssz_rs::Serializable for GetMetaData {
     }
 }
 
-impl ssz_rs::Serialize for GetMetaData {
+impl ssz_rs::Serialize for GetMetadata {
     fn serialize(&self, _buffer: &mut Vec<u8>) -> Result<usize, ssz_rs::SerializeError> {
         Ok(0)
     }
 }
 
-impl ssz_rs::Deserialize for GetMetaData {
+impl ssz_rs::Deserialize for GetMetadata {
     fn deserialize(_encoding: &[u8]) -> Result<Self, ssz_rs::DeserializeError>
     where
         Self: Sized,
     {
-        Ok(GetMetaData)
+        Ok(GetMetadata)
     }
 }
 
@@ -142,7 +137,7 @@ pub enum Response {
     Status(Status),
     GoodbyeReason(GoodbyeReason),
     Pong(Pong),
-    MetaData(MetaData),
+    Metadata(Metadata),
     PooledUserOpHashes(PooledUserOpHashes),
     PooledUserOpsByHash(PooledUserOpsByHash),
 }
@@ -154,7 +149,7 @@ impl Response {
             Response::Status(status) => status.serialize(&mut buffer),
             Response::GoodbyeReason(reason) => reason.serialize(&mut buffer),
             Response::Pong(pong) => pong.serialize(&mut buffer),
-            Response::MetaData(metadata) => metadata.serialize(&mut buffer),
+            Response::Metadata(metadata) => metadata.serialize(&mut buffer),
             Response::PooledUserOpHashes(pooled_user_op_hashes) => {
                 pooled_user_op_hashes.serialize(&mut buffer)
             }

--- a/crates/p2p/src/request_response/upgrade.rs
+++ b/crates/p2p/src/request_response/upgrade.rs
@@ -35,7 +35,7 @@ impl UpgradeInfo for OutboundRepUpgrade {
             Request::Status(_) => vec![ProtocolId::new(Protocol::Status)],
             Request::GoodbyeReason(_) => vec![ProtocolId::new(Protocol::Goodbye)],
             Request::Ping(_) => vec![ProtocolId::new(Protocol::Ping)],
-            Request::GetMetaData(_) => vec![ProtocolId::new(Protocol::MetaData)],
+            Request::GetMetadata(_) => vec![ProtocolId::new(Protocol::MetaData)],
             Request::PooledUserOpHashesReq(_) => {
                 vec![ProtocolId::new(Protocol::PooledUserOpHashes)]
             }

--- a/crates/p2p/src/tests/req_rep.rs
+++ b/crates/p2p/src/tests/req_rep.rs
@@ -1,6 +1,6 @@
 use crate::{
     network::NetworkEvent,
-    request_response::{GetMetaData, Request, Response, Status},
+    request_response::{GetMetadata, Request, Response, Status},
     tests::build_connnected_p2p_pair,
 };
 use std::time::Duration;
@@ -98,8 +98,8 @@ async fn reqrep_ping_pong() -> eyre::Result<()> {
 #[tokio::test]
 async fn reqrep_metadata() -> eyre::Result<()> {
     reqrep_case(
-        Request::GetMetaData(GetMetaData),
-        Response::MetaData(Default::default()),
+        Request::GetMetadata(GetMetadata),
+        Response::Metadata(Default::default()),
     )
     .await?;
     Ok(())


### PR DESCRIPTION
This PR fixes connection problems with Skandha. We successfully establish connection and ping each other :rocket: 

@zsluedem There are several things we will have to do:
- we should probably move encoding logic to separate file (like in lighthouse: https://github.com/sigp/lighthouse/blob/stable/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs)
- handle result chunks codes
- update encoding for other reqresp message since they are not encoded correctly (i.e., if the list is in response you need to insert response chunk before each element of list)

Still useful to merge this so we can setup some p2p network in bundler test executor tests.