### PR TITLE
chore: move hash inside user operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           components: clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,22 +1706,10 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
- "enum-ordinalize 3.1.15",
+ "enum-ordinalize",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "educe"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93898956a40b4e5aadd52d57674426a14b0c5598ac5305b93b8560101083065"
-dependencies = [
- "enum-ordinalize 4.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.43",
 ]
 
 [[package]]
@@ -1830,26 +1818,6 @@ checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.43",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.43",
@@ -5987,7 +5955,7 @@ dependencies = [
  "cipher 0.4.4",
  "ctr 0.9.2",
  "digest 0.10.7",
- "educe 0.4.23",
+ "educe",
  "futures",
  "generic-array",
  "hmac 0.12.1",
@@ -6996,7 +6964,6 @@ dependencies = [
  "alloy-chains",
  "async-trait",
  "bin-layout",
- "educe 0.5.9",
  "enumset",
  "ethers 2.0.8",
  "eyre",
@@ -7052,7 +7019,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "alloy-chains",
  "async-stream",
- "educe 0.5.9",
+ "derive_more",
  "ethers 2.0.8",
  "expanded-pathbuf",
  "eyre",

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ run-silius-create-wallet:
 	cargo run --release -- create-wallet --output-path ${HOME}/.silius
 
 run-silius-debug:
-	cargo run --release -- node --eth-client-address ws://127.0.0.1:8546 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --http.api eth,debug,web3 --ws.api eth,debug,web3 --poll-interval 5
+	cargo run --release -- node --eth-client-address ws://127.0.0.1:8546 --mnemonic-file ${HOME}/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --http.api eth,debug,web3 --ws.api eth,debug,web3
 
 run-silius-debug-mode:
-	cargo run --profile debug-fast -- node --verbosity 4 --eth-client-address ws://127.0.0.1:8546 --mnemonic-file /home/vid/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --http.api eth,debug,web3 --ws.api eth,debug,web3 --poll-interval 5
+	cargo run --profile debug-fast -- node --verbosity 4 --eth-client-address ws://127.0.0.1:8546 --mnemonic-file /home/vid/.silius/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --beneficiary 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --entry-points 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --http --ws --http.api eth,debug,web3 --ws.api eth,debug,web3
 
 fetch-thirdparty:
 	git submodule update --init

--- a/bin/silius/src/bundler.rs
+++ b/bin/silius/src/bundler.rs
@@ -31,7 +31,7 @@ use silius_primitives::{
     provider::BlockStream,
     reputation::ReputationEntry,
     simulation::CodeHash,
-    UserOperation, UserOperationHash, Wallet,
+    UserOperationHash, UserOperationSigned, Wallet,
 };
 use silius_rpc::{
     debug_api::{DebugApiServer, DebugApiServerImpl},
@@ -105,17 +105,17 @@ where
         eth_client_version,
     );
 
-    let chain_id = eth_client.get_chainid().await?;
-    let chain_conn = Chain::from(chain_id.as_u64());
+    let chain_id = eth_client.get_chainid().await?.as_u64();
+    let chain_conn = Chain::from(chain_id);
 
     let wallet: Wallet;
     if args.send_bundle_mode == SendStrategy::Flashbots {
-        wallet = Wallet::from_file(args.mnemonic_file.into(), &chain_id, true)
+        wallet = Wallet::from_file(args.mnemonic_file.into(), chain_id, true)
             .map_err(|error| eyre::format_err!("Could not load mnemonic file: {}", error))?;
         info!("Wallet Signer {:?}", wallet.signer);
         info!("Flashbots Signer {:?}", wallet.flashbots_signer);
     } else {
-        wallet = Wallet::from_file(args.mnemonic_file.into(), &chain_id, false)
+        wallet = Wallet::from_file(args.mnemonic_file.into(), chain_id, false)
             .map_err(|error| eyre::format_err!("Could not load mnemonic file: {}", error))?;
         info!("{:?}", wallet.signer);
     }
@@ -189,7 +189,7 @@ where
                 args.min_priority_fee_per_gas,
             );
             let mempool = Mempool::new(
-                Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperation>::default())),
+                Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperationSigned>::default())),
                 Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
                 Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
                 Arc::new(RwLock::new(HashMap::<UserOperationHash, Vec<CodeHash>>::default())),
@@ -283,7 +283,7 @@ where
                 args.min_priority_fee_per_gas,
             );
             let mempool = Mempool::new(
-                Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperation>::default())),
+                Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperationSigned>::default())),
                 Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
                 Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
                 Arc::new(RwLock::new(HashMap::<UserOperationHash, Vec<CodeHash>>::default())),
@@ -472,11 +472,11 @@ pub fn create_wallet(args: CreateWalletArgs) -> eyre::Result<()> {
     let path = unwrap_path_or_home(args.output_path)?;
 
     if args.flashbots_key {
-        let wallet = Wallet::build_random(path, &args.chain_id, true)?;
+        let wallet = Wallet::build_random(path, args.chain_id, true)?;
         info!("Wallet signer {:?}", wallet.signer);
         info!("Flashbots signer {:?}", wallet.flashbots_signer);
     } else {
-        let wallet = Wallet::build_random(path, &args.chain_id, false)?;
+        let wallet = Wallet::build_random(path, args.chain_id, false)?;
         info!("Wallet signer {:?}", wallet.signer);
     }
 

--- a/bin/silius/src/cli/args.rs
+++ b/bin/silius/src/cli/args.rs
@@ -228,8 +228,8 @@ pub struct CreateWalletArgs {
     pub output_path: Option<ExpandedPathBuf>,
 
     /// The chain id.
-    #[clap(long, value_parser=parse_u256, default_value="1")]
-    pub chain_id: U256,
+    #[clap(long, default_value = "1")]
+    pub chain_id: u64,
 
     /// Whether to create a Flashbots key.
     #[clap(long, default_value_t = false)]

--- a/crates/bundler/src/bundler.rs
+++ b/crates/bundler/src/bundler.rs
@@ -161,9 +161,7 @@ where
         info!(
             "Creating a new bundle with {} user operations: {:?}",
             uos.len(),
-            uos.iter()
-                .map(|uo| uo.hash(&self.entry_point, &self.chain.id().into()))
-                .collect::<Vec<UserOperationHash>>()
+            uos.iter().map(|uo| uo.hash).collect::<Vec<UserOperationHash>>()
         );
         trace!("Bundle content: {uos:?}");
 
@@ -178,6 +176,7 @@ where
     ///
     /// # Arguments
     /// * `client` - A provider that implements [Middleware](Middleware) trait
+    /// * `uos` - Vector of [UserOperations](UserOperation)
     ///
     /// # Returns
     /// * `TypedTransaction` - A [TypedTransaction](TypedTransaction)
@@ -201,8 +200,12 @@ where
             self.beneficiary
         };
 
-        let mut tx: TypedTransaction =
-            ep.handle_ops(uos.clone().into_iter().map(Into::into).collect(), beneficiary).tx;
+        let mut tx: TypedTransaction = ep
+            .handle_ops(
+                uos.clone().into_iter().map(|uo| uo.user_operation.into()).collect(),
+                beneficiary,
+            )
+            .tx;
 
         match self.chain.id() {
             // Mumbai
@@ -521,7 +524,7 @@ mod test {
 
         let eth_client = Arc::new(Provider::<Ws>::connect(anvil.ws_endpoint()).await?);
         let ep_address = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789".parse::<Address>()?;
-        let wallet = Wallet::from_phrase(KEY_PHRASE, &anvil.chain_id().into(), true)?;
+        let wallet = Wallet::from_phrase(KEY_PHRASE, anvil.chain_id(), true)?;
 
         // Create a bundler and connect to the Anvil
         let bundler = Bundler::new(
@@ -559,7 +562,7 @@ mod test {
             "{}/.silius/0x129D197b2a989C6798601A49D89a4AEC822A17a3",
             std::env::var("HOME").unwrap()
         );
-        let wallet = Wallet::from_file(dir.into(), &U256::from(5), true)?;
+        let wallet = Wallet::from_file(dir.into(), 5, true)?;
 
         let bundler = Bundler::new(
             wallet.clone(),

--- a/crates/contracts/src/utils.rs
+++ b/crates/contracts/src/utils.rs
@@ -1,9 +1,9 @@
 use crate::gen::entry_point_api::{self, EntryPointAPICalls};
 use ethers::{abi::AbiDecode, types::Bytes};
-use silius_primitives::UserOperation;
+use silius_primitives::UserOperationSigned;
 
-impl From<UserOperation> for entry_point_api::UserOperation {
-    fn from(uo: UserOperation) -> Self {
+impl From<UserOperationSigned> for entry_point_api::UserOperation {
+    fn from(uo: UserOperationSigned) -> Self {
         Self {
             sender: uo.sender,
             nonce: uo.nonce,
@@ -20,7 +20,7 @@ impl From<UserOperation> for entry_point_api::UserOperation {
     }
 }
 
-impl From<entry_point_api::UserOperation> for UserOperation {
+impl From<entry_point_api::UserOperation> for UserOperationSigned {
     fn from(uo: entry_point_api::UserOperation) -> Self {
         Self {
             sender: uo.sender,
@@ -38,7 +38,7 @@ impl From<entry_point_api::UserOperation> for UserOperation {
     }
 }
 
-pub fn parse_from_input_data(data: Bytes) -> Option<Vec<UserOperation>> {
+pub fn parse_from_input_data(data: Bytes) -> Option<Vec<UserOperationSigned>> {
     EntryPointAPICalls::decode(data).ok().and_then(|call| match call {
         EntryPointAPICalls::HandleOps(ops) => {
             Some(ops.ops.into_iter().map(|op| op.into()).collect())

--- a/crates/grpc/src/proto.rs
+++ b/crates/grpc/src/proto.rs
@@ -96,6 +96,7 @@ pub mod types {
     impl From<silius_primitives::UserOperation> for UserOperation {
         fn from(user_operation: silius_primitives::UserOperation) -> Self {
             Self {
+                hash: Some(user_operation.hash.into()),
                 sender: Some(user_operation.sender.into()),
                 nonce: Some(user_operation.nonce.into()),
                 init_code: prost::bytes::Bytes::copy_from_slice(user_operation.init_code.as_ref()),
@@ -115,6 +116,98 @@ pub mod types {
 
     impl From<UserOperation> for silius_primitives::UserOperation {
         fn from(user_operation: UserOperation) -> Self {
+            Self {
+                hash: {
+                    if let Some(hash) = user_operation.hash {
+                        hash.into()
+                    } else {
+                        UserOperationHash::default()
+                    }
+                },
+                user_operation: silius_primitives::UserOperationSigned {
+                    sender: {
+                        if let Some(sender) = user_operation.sender {
+                            sender.into()
+                        } else {
+                            Address::zero()
+                        }
+                    },
+                    nonce: {
+                        if let Some(nonce) = user_operation.nonce {
+                            nonce.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    init_code: user_operation.init_code.into(),
+                    call_data: user_operation.call_data.into(),
+                    call_gas_limit: {
+                        if let Some(call_gas_limit) = user_operation.call_gas_limit {
+                            call_gas_limit.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    verification_gas_limit: {
+                        if let Some(verification_gas_limit) = user_operation.verification_gas_limit
+                        {
+                            verification_gas_limit.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    pre_verification_gas: {
+                        if let Some(pre_verification_gas) = user_operation.pre_verification_gas {
+                            pre_verification_gas.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    max_fee_per_gas: {
+                        if let Some(max_fee_per_gas) = user_operation.max_fee_per_gas {
+                            max_fee_per_gas.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    max_priority_fee_per_gas: {
+                        if let Some(max_priority_fee_per_gas) =
+                            user_operation.max_priority_fee_per_gas
+                        {
+                            max_priority_fee_per_gas.into()
+                        } else {
+                            U256::zero()
+                        }
+                    },
+                    paymaster_and_data: user_operation.paymaster_and_data.into(),
+                    signature: user_operation.signature.into(),
+                },
+            }
+        }
+    }
+
+    impl From<silius_primitives::UserOperationSigned> for UserOperationSigned {
+        fn from(user_operation: silius_primitives::UserOperationSigned) -> Self {
+            Self {
+                sender: Some(user_operation.sender.into()),
+                nonce: Some(user_operation.nonce.into()),
+                init_code: prost::bytes::Bytes::copy_from_slice(user_operation.init_code.as_ref()),
+                call_data: prost::bytes::Bytes::copy_from_slice(user_operation.call_data.as_ref()),
+                call_gas_limit: Some(user_operation.call_gas_limit.into()),
+                verification_gas_limit: Some(user_operation.verification_gas_limit.into()),
+                pre_verification_gas: Some(user_operation.pre_verification_gas.into()),
+                max_fee_per_gas: Some(user_operation.max_fee_per_gas.into()),
+                max_priority_fee_per_gas: Some(user_operation.max_priority_fee_per_gas.into()),
+                paymaster_and_data: prost::bytes::Bytes::copy_from_slice(
+                    user_operation.paymaster_and_data.as_ref(),
+                ),
+                signature: prost::bytes::Bytes::copy_from_slice(user_operation.signature.as_ref()),
+            }
+        }
+    }
+
+    impl From<UserOperationSigned> for silius_primitives::UserOperationSigned {
+        fn from(user_operation: UserOperationSigned) -> Self {
             Self {
                 sender: {
                     if let Some(sender) = user_operation.sender {

--- a/crates/grpc/src/proto.rs
+++ b/crates/grpc/src/proto.rs
@@ -1,10 +1,8 @@
 // Code adapted from: https://github.com/ledgerwatch/interfaces/blob/master/src/lib.rs#L1
 pub mod types {
-
     use arrayref::array_ref;
     use ethers::types::{Address, Bloom, U256};
     use prost::bytes::Buf;
-    use silius_primitives::{reputation::Status, UserOperationHash};
     use std::str::FromStr;
 
     tonic::include_proto!("types");
@@ -73,7 +71,7 @@ pub mod types {
         }
     }
 
-    impl From<H256> for UserOperationHash {
+    impl From<H256> for silius_primitives::UserOperationHash {
         fn from(val: H256) -> Self {
             Self::from(ethers::types::H256::from(val))
         }
@@ -97,19 +95,27 @@ pub mod types {
         fn from(user_operation: silius_primitives::UserOperation) -> Self {
             Self {
                 hash: Some(user_operation.hash.into()),
-                sender: Some(user_operation.sender.into()),
-                nonce: Some(user_operation.nonce.into()),
-                init_code: prost::bytes::Bytes::copy_from_slice(user_operation.init_code.as_ref()),
-                call_data: prost::bytes::Bytes::copy_from_slice(user_operation.call_data.as_ref()),
-                call_gas_limit: Some(user_operation.call_gas_limit.into()),
-                verification_gas_limit: Some(user_operation.verification_gas_limit.into()),
-                pre_verification_gas: Some(user_operation.pre_verification_gas.into()),
-                max_fee_per_gas: Some(user_operation.max_fee_per_gas.into()),
-                max_priority_fee_per_gas: Some(user_operation.max_priority_fee_per_gas.into()),
-                paymaster_and_data: prost::bytes::Bytes::copy_from_slice(
-                    user_operation.paymaster_and_data.as_ref(),
-                ),
-                signature: prost::bytes::Bytes::copy_from_slice(user_operation.signature.as_ref()),
+                uo: Some(UserOperationSigned {
+                    sender: Some(user_operation.sender.into()),
+                    nonce: Some(user_operation.nonce.into()),
+                    init_code: prost::bytes::Bytes::copy_from_slice(
+                        user_operation.init_code.as_ref(),
+                    ),
+                    call_data: prost::bytes::Bytes::copy_from_slice(
+                        user_operation.call_data.as_ref(),
+                    ),
+                    call_gas_limit: Some(user_operation.call_gas_limit.into()),
+                    verification_gas_limit: Some(user_operation.verification_gas_limit.into()),
+                    pre_verification_gas: Some(user_operation.pre_verification_gas.into()),
+                    max_fee_per_gas: Some(user_operation.max_fee_per_gas.into()),
+                    max_priority_fee_per_gas: Some(user_operation.max_priority_fee_per_gas.into()),
+                    paymaster_and_data: prost::bytes::Bytes::copy_from_slice(
+                        user_operation.paymaster_and_data.as_ref(),
+                    ),
+                    signature: prost::bytes::Bytes::copy_from_slice(
+                        user_operation.signature.as_ref(),
+                    ),
+                }),
             }
         }
     }
@@ -121,66 +127,15 @@ pub mod types {
                     if let Some(hash) = user_operation.hash {
                         hash.into()
                     } else {
-                        UserOperationHash::default()
+                        silius_primitives::UserOperationHash::default()
                     }
                 },
-                user_operation: silius_primitives::UserOperationSigned {
-                    sender: {
-                        if let Some(sender) = user_operation.sender {
-                            sender.into()
-                        } else {
-                            Address::zero()
-                        }
-                    },
-                    nonce: {
-                        if let Some(nonce) = user_operation.nonce {
-                            nonce.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    init_code: user_operation.init_code.into(),
-                    call_data: user_operation.call_data.into(),
-                    call_gas_limit: {
-                        if let Some(call_gas_limit) = user_operation.call_gas_limit {
-                            call_gas_limit.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    verification_gas_limit: {
-                        if let Some(verification_gas_limit) = user_operation.verification_gas_limit
-                        {
-                            verification_gas_limit.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    pre_verification_gas: {
-                        if let Some(pre_verification_gas) = user_operation.pre_verification_gas {
-                            pre_verification_gas.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    max_fee_per_gas: {
-                        if let Some(max_fee_per_gas) = user_operation.max_fee_per_gas {
-                            max_fee_per_gas.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    max_priority_fee_per_gas: {
-                        if let Some(max_priority_fee_per_gas) =
-                            user_operation.max_priority_fee_per_gas
-                        {
-                            max_priority_fee_per_gas.into()
-                        } else {
-                            U256::zero()
-                        }
-                    },
-                    paymaster_and_data: user_operation.paymaster_and_data.into(),
-                    signature: user_operation.signature.into(),
+                user_operation: {
+                    if let Some(uo) = user_operation.uo {
+                        uo.into()
+                    } else {
+                        silius_primitives::UserOperationSigned::default()
+                    }
                 },
             }
         }
@@ -273,7 +228,7 @@ pub mod types {
                 addr: Some(reputation_entry.address.into()),
                 uo_seen: reputation_entry.uo_seen,
                 uo_included: reputation_entry.uo_included,
-                stat: match Status::from(reputation_entry.status) {
+                stat: match silius_primitives::reputation::Status::from(reputation_entry.status) {
                     silius_primitives::reputation::Status::OK => ReputationStatus::Ok,
                     silius_primitives::reputation::Status::THROTTLED => ReputationStatus::Throttled,
                     silius_primitives::reputation::Status::BANNED => ReputationStatus::Banned,
@@ -401,8 +356,8 @@ pub mod types {
         }
     }
 
-    impl From<UserOperationHash> for H256 {
-        fn from(value: UserOperationHash) -> Self {
+    impl From<silius_primitives::UserOperationHash> for H256 {
+        fn from(value: silius_primitives::UserOperationHash) -> Self {
             Self::from(value.0)
         }
     }

--- a/crates/grpc/src/protos/types/types.proto
+++ b/crates/grpc/src/protos/types/types.proto
@@ -26,6 +26,21 @@ message SupportedEntryPoint {
 }
 
 message UserOperation {
+    types.H256 hash = 1;
+    types.H160 sender = 2;
+    PbU256 nonce = 3;
+    bytes init_code = 4;
+    bytes call_data = 5;
+    PbU256 call_gas_limit = 6;
+    PbU256 verification_gas_limit = 7;
+    PbU256 pre_verification_gas = 8;
+    PbU256 max_fee_per_gas = 9;
+    PbU256 max_priority_fee_per_gas = 10;
+    bytes paymaster_and_data = 11;
+    bytes signature = 12;
+}
+
+message UserOperationSigned {
     types.H160 sender = 1;
     PbU256 nonce = 2;
     bytes init_code = 3;

--- a/crates/grpc/src/protos/types/types.proto
+++ b/crates/grpc/src/protos/types/types.proto
@@ -27,17 +27,7 @@ message SupportedEntryPoint {
 
 message UserOperation {
     types.H256 hash = 1;
-    types.H160 sender = 2;
-    PbU256 nonce = 3;
-    bytes init_code = 4;
-    bytes call_data = 5;
-    PbU256 call_gas_limit = 6;
-    PbU256 verification_gas_limit = 7;
-    PbU256 pre_verification_gas = 8;
-    PbU256 max_fee_per_gas = 9;
-    PbU256 max_priority_fee_per_gas = 10;
-    bytes paymaster_and_data = 11;
-    bytes signature = 12;
+    UserOperationSigned uo = 2;
 }
 
 message UserOperationSigned {

--- a/crates/grpc/src/protos/uopool/uopool.proto
+++ b/crates/grpc/src/protos/uopool/uopool.proto
@@ -83,7 +83,7 @@ message UserOperationHashRequest{
 }
 
 message GetUserOperationByHashResponse{
-    types.UserOperation user_operation = 1;
+    types.UserOperationSigned user_operation = 1;
     types.H160 entry_point = 2;
     types.H256 transaction_hash = 3;
     types.H256 block_hash = 4;

--- a/crates/grpc/src/uopool.rs
+++ b/crates/grpc/src/uopool.rs
@@ -92,7 +92,7 @@ where
         &self,
         ep: &Address,
     ) -> tonic::Result<StandardUserPool<M, T, Y, X, Z, H, R, SanCk, SimCk, SimTrCk>> {
-        let m_id = mempool_id(ep, &U256::from(self.chain.id()));
+        let m_id = mempool_id(ep, self.chain.id());
         self.uopools
             .read()
             .get(&m_id)
@@ -425,7 +425,7 @@ where
             let mut entrypoint_channels: EntrypointChannels = Vec::new();
 
             for (ep, block_stream) in eps.into_iter().zip(block_streams.into_iter()) {
-                let id = mempool_id(&ep, &U256::from(chain.id()));
+                let id = mempool_id(&ep, chain.id());
                 let (waiting_to_pub_sd, waiting_to_pub_rv) = unbounded::<(UserOperation, U256)>();
                 let uo_builder = UoPoolBuilder::new(
                     eth_client.clone(),
@@ -531,7 +531,7 @@ where
             });
         } else {
             for (ep, block_stream) in eps.into_iter().zip(block_streams.into_iter()) {
-                let id = mempool_id(&ep, &U256::from(chain.id()));
+                let id = mempool_id(&ep, chain.id());
                 let uo_builder = UoPoolBuilder::new(
                     eth_client.clone(),
                     ep,

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -35,7 +35,6 @@ tokio = { workspace = true }
 
 # misc
 bin-layout = "7.1.0"
-educe = { version = "0.5.9", features = ["Debug", "Default"] }
 enumset = "1.1.3"
 eyre = { workspace = true }
 page_size = "0.6.0"

--- a/crates/mempool/src/database/tables.rs
+++ b/crates/mempool/src/database/tables.rs
@@ -1,12 +1,12 @@
 use super::utils::{
-    WrapAddress, WrapCodeHashVec, WrapReputationEntry, WrapUserOpSet, WrapUserOperation,
-    WrapUserOperationHash,
+    WrapAddress, WrapCodeHashVec, WrapReputationEntry, WrapUserOpSet, WrapUserOperationHash,
+    WrapUserOperationSigned,
 };
 use reth_db::{table, TableType};
 
 table!(
     /// Stores the user operations
-    ( UserOperations ) WrapUserOperationHash | WrapUserOperation
+    ( UserOperations ) WrapUserOperationHash | WrapUserOperationSigned
 );
 
 table!(

--- a/crates/mempool/src/database/utils.rs
+++ b/crates/mempool/src/database/utils.rs
@@ -7,7 +7,7 @@ use ethers::{
 use reth_db::table::{Compress, Decode, Decompress, Encode};
 use serde::{Deserialize, Serialize};
 use silius_primitives::{
-    reputation::ReputationEntry, simulation::CodeHash, UserOperation, UserOperationHash,
+    reputation::ReputationEntry, simulation::CodeHash, UserOperationHash, UserOperationSigned,
 };
 use std::{collections::HashSet, fmt::Debug};
 
@@ -108,7 +108,7 @@ construct_wrap_hash!(Address, WrapAddress, 20);
 construct_wrap_hash!(UserOperationHash, WrapUserOperationHash, 32);
 
 construct_wrap_struct!(CodeHash, WrapCodeHash);
-construct_wrap_struct!(UserOperation, WrapUserOperation);
+construct_wrap_struct!(UserOperationSigned, WrapUserOperationSigned);
 construct_wrap_struct!(ReputationEntry, WrapReputationEntry);
 
 impl<'de> Decoder<'de> for WrapUserOperationHash {

--- a/crates/mempool/src/validate/simulation_trace/code_hashes.rs
+++ b/crates/mempool/src/validate/simulation_trace/code_hashes.rs
@@ -100,17 +100,15 @@ impl<M: Middleware> SimulationTraceCheck<M> for CodeHashes {
         let hashes: &mut Vec<CodeHash> = &mut vec![];
         self.get_code_hashes(addrs, hashes, &helper.entry_point.eth_client()).await?;
 
-        let uo_hash = uo.hash(&helper.entry_point.address(), &helper.chain.id().into());
-
-        match mempool.has_code_hashes(&uo_hash) {
+        match mempool.has_code_hashes(&uo.hash) {
             Ok(true) => {
                 // 2nd simulation
                 let hashes_prev = mempool
-                    .get_code_hashes(&uo_hash)
+                    .get_code_hashes(&uo.hash)
                     .map_err(|err| SimulationError::Other { inner: err.to_string() })?;
                 debug!(
                     "Veryfing {:?} code hashes in 2nd simulation: {:?} vs {:?}",
-                    uo_hash, hashes, hashes_prev
+                    uo.hash, hashes, hashes_prev
                 );
                 if !equal_code_hashes(hashes, &hashes_prev) {
                     return Err(SimulationError::CodeHashes {});

--- a/crates/mempool/src/validate/validator.rs
+++ b/crates/mempool/src/validate/validator.rs
@@ -174,7 +174,7 @@ where
         &self,
         uo: &UserOperation,
     ) -> Result<SimulateValidationResult, SimulationError> {
-        match self.entry_point.simulate_validation(uo.clone()).await {
+        match self.entry_point.simulate_validation(uo.user_operation.clone()).await {
             Ok(res) => Ok(res),
             Err(err) => Err(match err {
                 EntryPointError::FailedOp(op) => SimulationError::Validation { inner: op.reason },
@@ -198,7 +198,7 @@ where
         &self,
         uo: &UserOperation,
     ) -> Result<GethTrace, SimulationError> {
-        match self.entry_point.simulate_validation_trace(uo.clone()).await {
+        match self.entry_point.simulate_validation_trace(uo.user_operation.clone()).await {
             Ok(trace) => Ok(trace),
             Err(err) => Err(match err {
                 EntryPointError::FailedOp(op) => SimulationError::Validation { inner: op.reason },
@@ -260,7 +260,7 @@ where
         }
 
         if let Some(uo) = mempool.get_prev_by_sender(uo) {
-            out.prev_hash = Some(uo.hash(&self.entry_point.address(), &self.chain.id().into()));
+            out.prev_hash = Some(uo.hash);
         }
         debug!("Simulate user operation from {:?}", uo.sender);
         let sim_res = self.simulate_validation(uo).await?;

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -156,11 +156,14 @@ impl Network {
                         return None;
                     }
                 };
-                self.entrypoint_channels.iter().find_map(|(_, ep, _, new_coming_uos_ch)| {
+                self.entrypoint_channels.iter().find_map(|(chain, ep, _, new_coming_uos_ch)| {
                     if *ep == userops.entrypoint_address() {
                         for user_op in userops.clone().user_operations().into_iter() {
                             new_coming_uos_ch
-                                .unbounded_send(user_op)
+                                .unbounded_send(UserOperation::from_user_operation_signed(
+                                    user_op.hash(ep, chain.id()),
+                                    user_op,
+                                ))
                                 .expect("new useop channel should be open all the time");
                         }
                         Some(())

--- a/crates/p2p/src/request_response/models.rs
+++ b/crates/p2p/src/request_response/models.rs
@@ -1,5 +1,5 @@
 use crate::config::Metadata;
-use silius_primitives::UserOperation;
+use silius_primitives::UserOperationSigned;
 use ssz_rs::{List, Serialize, Vector};
 use std::io;
 
@@ -169,7 +169,7 @@ pub struct PooledUserOpHashes {
 
 #[derive(ssz_rs_derive::Serializable, Clone, Debug, PartialEq, Default)]
 pub struct PooledUserOpsByHash {
-    hashes: List<UserOperation, 1024>,
+    hashes: List<UserOperationSigned, 1024>,
 }
 
 #[derive(Clone, Default)]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { workspace = true }
 tokio = { workspace = true }
 
 # misc
-educe = { version = "0.5.9", features = ["Debug", "Default"] }
+derive_more = "0.99.17"
 expanded-pathbuf = { workspace = true }
 eyre = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -19,7 +19,7 @@ pub use mempool::Mode as UoPoolMode;
 pub use p2p::{PooledUserOps, UserOperationsWithEntryPoint};
 pub use user_operation::{
     UserOperation, UserOperationByHash, UserOperationGasEstimation, UserOperationHash,
-    UserOperationPartial, UserOperationReceipt,
+    UserOperationReceipt, UserOperationRequest, UserOperationSigned,
 };
 pub use utils::get_address;
 pub use wallet::Wallet;

--- a/crates/primitives/src/reputation.rs
+++ b/crates/primitives/src/reputation.rs
@@ -1,7 +1,6 @@
 //! Primitives for reputation
 
 use super::utils::{as_checksum_addr, as_hex_string, as_u64};
-use educe::Educe;
 use ethers::{
     prelude::{EthAbiCodec, EthAbiType},
     types::{Address, U256},
@@ -11,8 +10,7 @@ use serde::{Deserialize, Serialize};
 pub type ReputationStatus = u64;
 
 /// All possible reputation statuses
-#[derive(Default, Clone, Educe, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
-#[educe(Debug)]
+#[derive(Default, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
     #[default]
@@ -46,7 +44,7 @@ impl From<ReputationStatus> for Status {
 #[derive(
     Default,
     Clone,
-    Educe,
+    Debug,
     Eq,
     PartialEq,
     PartialOrd,
@@ -56,7 +54,6 @@ impl From<ReputationStatus> for Status {
     EthAbiCodec,
     EthAbiType,
 )]
-#[educe(Debug)]
 pub struct ReputationEntry {
     pub address: Address,
     #[serde(rename = "opsSeen", serialize_with = "as_hex_string")]
@@ -74,8 +71,7 @@ impl ReputationEntry {
 }
 
 /// Stake info
-#[derive(Clone, Copy, Default, Educe, Eq, PartialEq, Serialize, Deserialize)]
-#[educe(Debug)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StakeInfo {
     #[serde(rename = "addr", serialize_with = "as_checksum_addr")]
     pub address: Address,
@@ -92,8 +88,7 @@ impl StakeInfo {
 }
 
 /// Stake info response for RPC
-#[derive(Clone, Copy, Default, Educe, Eq, PartialEq, Serialize, Deserialize)]
-#[educe(Debug)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StakeInfoResponse {
     #[serde(rename = "stakeInfo")]
     pub stake_info: StakeInfo,

--- a/crates/primitives/src/user_operation/hash.rs
+++ b/crates/primitives/src/user_operation/hash.rs
@@ -1,0 +1,69 @@
+//! User operation hash related types and helpers
+
+use ethers::types::H256;
+use rustc_hex::FromHexError;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// User operation hash
+#[derive(
+    Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy, Default, PartialOrd, Ord,
+)]
+pub struct UserOperationHash(pub H256);
+
+impl From<H256> for UserOperationHash {
+    fn from(value: H256) -> Self {
+        Self(value)
+    }
+}
+
+impl From<UserOperationHash> for H256 {
+    fn from(value: UserOperationHash) -> Self {
+        value.0
+    }
+}
+
+impl From<[u8; 32]> for UserOperationHash {
+    fn from(value: [u8; 32]) -> Self {
+        Self(H256::from_slice(&value))
+    }
+}
+
+impl FromStr for UserOperationHash {
+    type Err = FromHexError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        H256::from_str(s).map(|h| h.into())
+    }
+}
+
+impl UserOperationHash {
+    #[inline]
+    pub const fn as_fixed_bytes(&self) -> &[u8; 32] {
+        &self.0 .0
+    }
+
+    #[inline]
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.0 .0
+    }
+
+    #[inline]
+    pub const fn repeat_byte(byte: u8) -> UserOperationHash {
+        UserOperationHash(H256([byte; 32]))
+    }
+
+    #[inline]
+    pub const fn zero() -> UserOperationHash {
+        UserOperationHash::repeat_byte(0u8)
+    }
+
+    pub fn assign_from_slice(&mut self, src: &[u8]) {
+        self.as_bytes_mut().copy_from_slice(src);
+    }
+
+    pub fn from_slice(src: &[u8]) -> Self {
+        let mut ret = Self::zero();
+        ret.assign_from_slice(src);
+        ret
+    }
+}

--- a/crates/primitives/src/user_operation/request.rs
+++ b/crates/primitives/src/user_operation/request.rs
@@ -1,0 +1,106 @@
+//! User operation request (optional fields)
+
+use super::UserOperationSigned;
+use crate::utils::{as_checksum_addr, as_checksum_bytes};
+use ethers::types::{Address, Bytes, U256};
+use serde::{Deserialize, Serialize};
+
+/// User operation with all fields being optional
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserOperationRequest {
+    #[serde(default = "Address::zero", serialize_with = "as_checksum_addr")]
+    pub sender: Address,
+    #[serde(default)]
+    pub nonce: U256,
+    #[serde(default, serialize_with = "as_checksum_bytes")]
+    pub init_code: Bytes,
+    #[serde(default)]
+    pub call_data: Bytes,
+    #[serde(default)]
+    pub call_gas_limit: Option<U256>,
+    #[serde(default)]
+    pub verification_gas_limit: Option<U256>,
+    #[serde(default)]
+    pub pre_verification_gas: Option<U256>,
+    #[serde(default)]
+    pub max_fee_per_gas: Option<U256>,
+    #[serde(default)]
+    pub max_priority_fee_per_gas: Option<U256>,
+    #[serde(default)]
+    pub paymaster_and_data: Bytes,
+    #[serde(default)]
+    pub signature: Option<Bytes>,
+}
+
+impl From<UserOperationRequest> for UserOperationSigned {
+    fn from(user_operation: UserOperationRequest) -> Self {
+        Self {
+            sender: user_operation.sender,
+            nonce: user_operation.nonce,
+            init_code: user_operation.init_code,
+            call_data: user_operation.call_data,
+            call_gas_limit: {
+                if let Some(call_gas_limit) = user_operation.call_gas_limit {
+                    call_gas_limit
+                } else {
+                    U256::zero()
+                }
+            },
+            verification_gas_limit: {
+                if let Some(verification_gas_limit) = user_operation.verification_gas_limit {
+                    verification_gas_limit
+                } else {
+                    U256::zero()
+                }
+            },
+            pre_verification_gas: {
+                if let Some(pre_verification_gas) = user_operation.pre_verification_gas {
+                    pre_verification_gas
+                } else {
+                    U256::zero()
+                }
+            },
+            max_fee_per_gas: {
+                if let Some(max_fee_per_gas) = user_operation.max_fee_per_gas {
+                    max_fee_per_gas
+                } else {
+                    U256::zero()
+                }
+            },
+            max_priority_fee_per_gas: {
+                if let Some(max_priority_fee_per_gas) = user_operation.max_priority_fee_per_gas {
+                    max_priority_fee_per_gas
+                } else {
+                    U256::zero()
+                }
+            },
+            paymaster_and_data: user_operation.paymaster_and_data,
+            signature: {
+                if let Some(signature) = user_operation.signature {
+                    signature
+                } else {
+                    Bytes::default()
+                }
+            },
+        }
+    }
+}
+
+impl From<UserOperationSigned> for UserOperationRequest {
+    fn from(user_operation: UserOperationSigned) -> Self {
+        Self {
+            sender: user_operation.sender,
+            nonce: user_operation.nonce,
+            init_code: user_operation.init_code,
+            call_data: user_operation.call_data,
+            call_gas_limit: Some(user_operation.call_gas_limit),
+            verification_gas_limit: Some(user_operation.verification_gas_limit),
+            pre_verification_gas: Some(user_operation.pre_verification_gas),
+            max_fee_per_gas: Some(user_operation.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(user_operation.max_priority_fee_per_gas),
+            paymaster_and_data: user_operation.paymaster_and_data,
+            signature: Some(user_operation.signature),
+        }
+    }
+}

--- a/crates/rpc/src/debug_api.rs
+++ b/crates/rpc/src/debug_api.rs
@@ -4,7 +4,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
 use silius_primitives::{
     reputation::{ReputationEntry, StakeInfoResponse},
-    BundlerMode, UserOperation,
+    BundlerMode, UserOperationRequest,
 };
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
@@ -46,9 +46,10 @@ pub trait DebugApi {
     /// * `entry_point: Address` - The address of the entry point.
     ///
     /// # Returns
-    /// * `RpcResult<Vec<UserOperation>>` - A vector of [UserOperations](UserOperation) returned
+    /// * `RpcResult<Vec<UserOperation>>` - A vector of [UserOperations](UserOperationRequest)
+    ///   returned
     #[method(name = "dumpMempool")]
-    async fn dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<UserOperation>>;
+    async fn dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<UserOperationRequest>>;
 
     /// Set the reputations for the given array of [ReputationEntry](ReputationEntry)
     ///

--- a/crates/rpc/src/eth_api.rs
+++ b/crates/rpc/src/eth_api.rs
@@ -2,8 +2,8 @@ pub use crate::eth::EthApiServerImpl;
 use ethers::types::{Address, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use silius_primitives::{
-    UserOperation, UserOperationByHash, UserOperationGasEstimation, UserOperationHash,
-    UserOperationPartial, UserOperationReceipt,
+    UserOperationByHash, UserOperationGasEstimation, UserOperationHash, UserOperationReceipt,
+    UserOperationRequest,
 };
 
 /// The ERC-4337 `eth` namespace RPC methods trait
@@ -27,7 +27,7 @@ pub trait EthApi {
     /// Send a [UserOperation](UserOperation).
     ///
     /// # Arguments
-    /// * `user_operation: UserOperation` - The [UserOperation](UserOperation) to be sent.
+    /// * `user_operation: UserOperation` - The [UserOperation](UserOperationRequest) to be sent.
     /// * `entry_point: Address` - The address of the entry point.
     ///
     /// # Returns
@@ -35,7 +35,7 @@ pub trait EthApi {
     #[method(name = "sendUserOperation")]
     async fn send_user_operation(
         &self,
-        user_operation: UserOperation,
+        user_operation: UserOperationRequest,
         entry_point: Address,
     ) -> RpcResult<UserOperationHash>;
 
@@ -44,8 +44,8 @@ pub trait EthApi {
     /// See [How ERC-4337 Gas Estimation Works](https://www.alchemy.com/blog/erc-4337-gas-estimation).
     ///
     /// # Arguments
-    /// * `user_operation: [UserOperationPartial](UserOperationPartial)` - A [partial user
-    ///   operation](UserOperationPartial) for which to estimate the gas.
+    /// * `user_operation: [UserOperation](UserOperationRequest)` - User operation for which to
+    ///   estimate the gas.
     /// * `entry_point: Address` - The address of the entry point.
     ///
     /// # Returns
@@ -54,7 +54,7 @@ pub trait EthApi {
     #[method(name = "estimateUserOperationGas")]
     async fn estimate_user_operation_gas(
         &self,
-        user_operation: UserOperationPartial,
+        user_operation: UserOperationRequest,
         entry_point: Address,
     ) -> RpcResult<UserOperationGasEstimation>;
 

--- a/examples/simple-account/examples/create.rs
+++ b/examples/simple-account/examples/create.rs
@@ -8,7 +8,7 @@ use examples_simple_account::{
     simple_account::SimpleAccountExecute, EstimateResult, Request, Response,
 };
 use reqwest;
-use silius_primitives::{constants::entry_point::ADDRESS, UserOperation, Wallet as UoWallet};
+use silius_primitives::{constants::entry_point::ADDRESS, UserOperationSigned, Wallet as UoWallet};
 use silius_tests::common::gen::SimpleAccountFactory;
 use std::{env, sync::Arc, time::Duration};
 
@@ -59,7 +59,7 @@ async fn main() -> eyre::Result<()> {
 
         let execution = SimpleAccountExecute::new(Address::zero(), U256::from(0), Bytes::default());
         println!("{:}", Bytes::from(execution.encode()));
-        let user_op = UserOperation {
+        let user_op = UserOperationSigned {
             sender: address,
             nonce,
             init_code: Bytes::from(init_code),
@@ -72,12 +72,12 @@ async fn main() -> eyre::Result<()> {
             paymaster_and_data: Bytes::new(),
             signature: Bytes::default(),
         };
-        let uo_wallet = UoWallet::from_phrase(seed_phrase.as_str(), &chain_id.into(), false)?;
+        let uo_wallet = UoWallet::from_phrase(seed_phrase.as_str(), chain_id, false)?;
         let user_op = uo_wallet
-            .sign_uo(&user_op, &ADDRESS.to_string().parse::<Address>()?, &chain_id.into())
+            .sign_user_operation(&user_op, &ADDRESS.to_string().parse::<Address>()?, chain_id)
             .await?;
 
-        let value = serde_json::to_value(&user_op).unwrap();
+        let value = serde_json::to_value(&user_op.user_operation).unwrap();
 
         let req_body = Request {
             jsonrpc: "2.0".into(),
@@ -98,23 +98,26 @@ async fn main() -> eyre::Result<()> {
         let v = serde_json::from_str::<Response<EstimateResult>>(&res)?;
         println!("json: {:?}", v);
 
-        let user_op = UserOperation {
+        let user_op = UserOperationSigned {
             pre_verification_gas: v.result.pre_verification_gas.saturating_add(U256::from(1000)),
             verification_gas_limit: v.result.verification_gas_limit,
             call_gas_limit: v.result.call_gas_limit.saturating_add(U256::from(2000)),
             max_priority_fee_per_gas: priority_fee,
             max_fee_per_gas: gas_price,
-            ..user_op
+            ..user_op.user_operation
         };
         let user_op = uo_wallet
-            .sign_uo(&user_op, &ADDRESS.to_string().parse::<Address>()?, &chain_id.into())
+            .sign_user_operation(&user_op, &ADDRESS.to_string().parse::<Address>()?, chain_id)
             .await?;
 
         let send_body = Request {
             jsonrpc: "2.0".into(),
             id: 1,
             method: "eth_sendUserOperation".into(),
-            params: vec![serde_json::to_value(&user_op).unwrap(), ADDRESS.to_string().into()],
+            params: vec![
+                serde_json::to_value(&user_op.user_operation).unwrap(),
+                ADDRESS.to_string().into(),
+            ],
         };
         let post = reqwest::Client::builder()
             .build()?

--- a/examples/storage/examples/memory.rs
+++ b/examples/storage/examples/memory.rs
@@ -13,7 +13,7 @@ use silius_primitives::{
     provider::create_http_provider,
     reputation::ReputationEntry,
     simulation::CodeHash,
-    UserOperation, UserOperationHash,
+    UserOperationHash, UserOperationSigned,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -33,7 +33,7 @@ async fn main() -> eyre::Result<()> {
         let chain = Chain::dev();
         let entry_point = EntryPoint::new(provider.clone(), ep);
         let mempool = Mempool::new(
-            Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperation>::default())),
+            Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperationSigned>::default())),
             Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
             Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
             Arc::new(RwLock::new(HashMap::<UserOperationHash, Vec<CodeHash>>::default())),

--- a/examples/user-operation/examples/user_operation.rs
+++ b/examples/user-operation/examples/user_operation.rs
@@ -1,5 +1,5 @@
 use ethers::types::Address;
-use silius_primitives::{UserOperation, Wallet};
+use silius_primitives::{UserOperationSigned, Wallet};
 use std::str::FromStr;
 
 pub const MNEMONIC_PHRASE: &str = "test test test test test test test test test test test junk";
@@ -9,20 +9,20 @@ pub const ENTRY_POINT: &str = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789";
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     // create wallet
-    let wallet = Wallet::from_phrase(MNEMONIC_PHRASE, &CHAIN_ID.into(), false)?;
+    let wallet = Wallet::from_phrase(MNEMONIC_PHRASE, CHAIN_ID, false)?;
     println!("Wallet address: {:?}", wallet.signer);
 
     // create simple user operation
-    let uo = UserOperation::default().verification_gas_limit(50_000.into());
+    let uo = UserOperationSigned::default().verification_gas_limit(50_000.into());
     println!("User operation: {:?}", uo);
 
     // calculate user operation hash
-    let uo_hash = uo.hash(&Address::from_str(ENTRY_POINT).unwrap(), &CHAIN_ID.into());
+    let uo_hash = uo.hash(&Address::from_str(ENTRY_POINT).unwrap(), CHAIN_ID);
     println!("User operation hash: {:?}", uo_hash);
 
     // sign user operation
     let uo_signed =
-        wallet.sign_uo(&uo, &Address::from_str(ENTRY_POINT).unwrap(), &CHAIN_ID.into()).await?;
+        wallet.sign_user_operation(&uo, &Address::from_str(ENTRY_POINT).unwrap(), CHAIN_ID).await?;
     println!("User operation signed: {:?}", uo_signed);
 
     Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.73.0"

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -16,7 +16,7 @@ use silius_mempool::{
     UserOperationsByEntity, UserOperationsBySender, WriteMap,
 };
 use silius_primitives::{
-    reputation::ReputationEntry, simulation::CodeHash, UserOperation, UserOperationHash,
+    reputation::ReputationEntry, simulation::CodeHash, UserOperationHash, UserOperationSigned,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -188,7 +188,7 @@ pub fn setup_database_mempool_reputation() -> (
 #[allow(clippy::type_complexity)]
 pub fn setup_memory_mempool_reputation() -> (
     Mempool<
-        Arc<RwLock<HashMap<UserOperationHash, silius_primitives::UserOperation>>>,
+        Arc<RwLock<HashMap<UserOperationHash, silius_primitives::UserOperationSigned>>>,
         Arc<RwLock<HashMap<H160, HashSet<UserOperationHash>>>>,
         Arc<RwLock<HashMap<H160, HashSet<UserOperationHash>>>>,
         Arc<RwLock<HashMap<UserOperationHash, Vec<CodeHash>>>>,
@@ -199,7 +199,7 @@ pub fn setup_memory_mempool_reputation() -> (
     >,
 ) {
     let mempool = Mempool::new(
-        Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperation>::default())),
+        Arc::new(RwLock::new(HashMap::<UserOperationHash, UserOperationSigned>::default())),
         Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
         Arc::new(RwLock::new(HashMap::<Address, HashSet<UserOperationHash>>::default())),
         Arc::new(RwLock::new(HashMap::<UserOperationHash, Vec<CodeHash>>::default())),

--- a/tests/src/estimate_gas_tests.rs
+++ b/tests/src/estimate_gas_tests.rs
@@ -13,7 +13,7 @@ use ethers::{
 };
 use silius_contracts::EntryPoint;
 use silius_mempool::{validate::validator::new_canonical, UoPool};
-use silius_primitives::{UserOperation, Wallet as UoWallet};
+use silius_primitives::{UserOperationSigned, Wallet as UoWallet};
 use std::sync::Arc;
 
 async fn setup_basic() -> eyre::Result<(
@@ -92,7 +92,7 @@ macro_rules! estimate_gas_with_init_code {
 
             let (_gas_price, priority_fee) = client.estimate_eip1559_fees(None).await?;
             let nonce = client.get_transaction_count(address, None).await?;
-            let user_op = UserOperation {
+            let user_op = UserOperationSigned {
                 sender: address,
                 nonce,
                 init_code: Bytes::from(init_code),
@@ -106,9 +106,9 @@ macro_rules! estimate_gas_with_init_code {
                 signature: Bytes::default(),
             };
 
-            let uo_wallet = UoWallet::from_phrase(SEED_PHRASE, &chain_id.into(), false)?;
+            let uo_wallet = UoWallet::from_phrase(SEED_PHRASE, chain_id, false)?;
             let user_op =
-                uo_wallet.sign_uo(&user_op, &entry_point.address, &chain_id.into()).await?;
+                uo_wallet.sign_user_operation(&user_op, &entry_point.address, chain_id).await?;
 
             let _ = uopool.estimate_user_operation_gas(&user_op).await.expect("estimate done");
             Ok(())


### PR DESCRIPTION
This PR refactors user operation structs into three structs:
- UserOperation (hash + canonical user operation)
- UserOperationSigned (canonical user operation)
- UserOperationRequest (user operation with some optional fields, used for RPC estimateUserOperationGas)