### PR TITLE
fix: uo by sender not removed bug

### DIFF
--- a/crates/mempool/src/database/mempool.rs
+++ b/crates/mempool/src/database/mempool.rs
@@ -81,6 +81,7 @@ macro_rules! impl_add_remove_user_op_hash {
                     } else {
                         tx.put::<UserOperationsBySender>(address.clone().into(), uo_hash_set)?;
                     }
+                    tx.commit()?;
                     Ok(true)
                 } else {
                     Ok(false)


### PR DESCRIPTION
This is a bug which caused people would see not enough stake error when they sent more than 4 userops.