### PR TITLE
feat: support loading private key

### DIFF
--- a/bin/silius/src/cli/args.rs
+++ b/bin/silius/src/cli/args.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     parse_address, parse_duration, parse_enr, parse_label_value, parse_send_bundle_mode,
-    parse_u256, parse_uopool_mode, validate_private_key,
+    parse_u256, parse_uopool_mode,
 };
 use alloy_chains::{Chain, NamedChain};
 use clap::{ArgGroup, Parser, ValueEnum};
@@ -52,11 +52,11 @@ pub struct BundlerArgs {
     pub mnemonic_file: Option<PathBuf>,
 
     /// Private key for the wallet
-    #[clap(long, value_parser=validate_private_key, group = "account")]
+    #[clap(long, group = "account")]
     pub private_key: Option<String>,
 
     /// Flashbots private key
-    #[clap(long, value_parser=validate_private_key, conflicts_with = "mnemonic_file")]
+    #[clap(long, conflicts_with = "mnemonic_file")]
     pub flashbots_private_key: Option<String>,
 
     /// The bundler beneficiary address.

--- a/bin/silius/src/utils.rs
+++ b/bin/silius/src/utils.rs
@@ -87,3 +87,19 @@ where
 
     Ok(())
 }
+
+pub fn validate_private_key(hex_string: &str) -> Result<String, String> {
+    let chars = hex_string.chars();
+
+    if chars.clone().count() != 64 {
+        return Err(format!("{hex_string} is not a valid private key"));
+    }
+
+    for c in chars {
+        if !c.is_ascii_hexdigit() {
+            return Err(format!("{hex_string} is not a valid hexadecimal string"));
+        }
+    }
+
+    Ok(String::from(hex_string))
+}

--- a/bin/silius/src/utils.rs
+++ b/bin/silius/src/utils.rs
@@ -87,19 +87,3 @@ where
 
     Ok(())
 }
-
-pub fn validate_private_key(hex_string: &str) -> Result<String, String> {
-    let chars = hex_string.chars();
-
-    if chars.clone().count() != 64 {
-        return Err(format!("{hex_string} is not a valid private key"));
-    }
-
-    for c in chars {
-        if !c.is_ascii_hexdigit() {
-            return Err(format!("{hex_string} is not a valid hexadecimal string"));
-        }
-    }
-
-    Ok(String::from(hex_string))
-}

--- a/crates/primitives/src/wallet.rs
+++ b/crates/primitives/src/wallet.rs
@@ -2,7 +2,7 @@
 
 use crate::{UserOperation, UserOperationSigned};
 use ethers::{
-    prelude::{k256::ecdsa::SigningKey, rand},
+    prelude::{k256::ecdsa::SigningKey, rand, LocalWallet},
     signers::{coins_bip39::English, MnemonicBuilder, Signer},
     types::Address,
 };
@@ -137,6 +137,35 @@ impl Wallet {
             })
         } else {
             Ok(Self { signer: wallet.with_chain_id(chain_id), flashbots_signer: None })
+        }
+    }
+
+    /// Create a new wallet from the given private key
+    /// if `flashbots_key` is true, then `flashbots_private_key` must be provided
+    ///
+    /// # Arguments
+    /// * `private_key` - The private key
+    /// * `chain_id` - The chain id of the blockchain network to be used
+    /// * `flashbots_key` - Whether to create a Flashbots key
+    /// * `flashbots_private_key` - The private key for the Flashbots wallet
+    ///
+    /// # Returns
+    /// * `Self` - A new `Wallet` instance
+    pub fn from_private_key(
+        private_key: &str,
+        chain_id: u64,
+        flashbots_key: bool,
+        flashbots_private_key: Option<&str>,
+    ) -> eyre::Result<Self> {
+        let wallet = private_key.parse::<LocalWallet>()?.with_chain_id(chain_id);
+        if flashbots_key {
+            let flashbots_wallet = flashbots_private_key
+                .expect("Flashbots private key is required")
+                .parse::<LocalWallet>()?
+                .with_chain_id(chain_id);
+            Ok(Self { signer: wallet, flashbots_signer: Some(flashbots_wallet) })
+        } else {
+            Ok(Self { signer: wallet, flashbots_signer: None })
         }
     }
 


### PR DESCRIPTION
To load using private key, we can now use the `--private-key` option. And if we want to load with private key using flashbots send bundle mode, we can pass another option `--flashbots-private-key`. An addition option is required for using flashbots mode while loading with private key, since the private key only maps to a single address without hierarchical derivation.

Sample command to load using private key:
`cargo run --release -- node --eth-client-address http://127.0.0.1:8545 --private-key 4c5e5d30… --beneficiary 0xf39Fd6e5… --entry-points 0x5FF137D4… --http --ws`

Sample command to load using private key with flashbots mode:
`cargo run --release -- node --eth-client-address http://127.0.0.1:8545 --private-key 4c5e5d30… --flashbots-private-key df218be...  --send-bundle-mode flashbots --beneficiary 0xf39Fd6e5… --entry-points 0x5FF137D4… --http --ws`

- The `--mnemonic-file` and `--private-key` options are mutually exclusive, one and only one can be used. 
- Similarly, `--flashbots-private-key` cannot be used in the same command as `--mnemonic-file`, and it cannot be used alone without the `--private-key` option; but it can be optional when `--private-key` is used.
- If `--send-bundle-mode` is not `flashbots` and `--flashbots-private-key` is provided, `--flashbots-private-key` will be ignored.

Additional considerations:
I added a `value-parser` for the `--private-key` and `--flashbot-private-key` arguments, and the current implementation only checks if there are 64 characters and if each char is an ASCII hexadecimal digit. Am wondering if this is sufficient or if theres another better way to do this:
```
pub fn validate_private_key(hex_string: &str) -> Result<String, String> {
    let chars = hex_string.chars();

    if chars.clone().count() != 64 {
        return Err(format!("{hex_string} is not a valid private key"));
    }

    for c in chars {
        if !c.is_ascii_hexdigit() {
            return Err(format!("{hex_string} is not a valid hexadecimal string"));
        }
    }

    Ok(String::from(hex_string))
}
```